### PR TITLE
Modernize: build from source with ZMQ, Ubuntu 22.04, CI/CD

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -1,0 +1,120 @@
+name: Build, Push & Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main branch
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
+            echo "::error::Tag must be on the main branch"
+            exit 1
+          fi
+
+      - name: Extract version from tag
+        id: meta
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if this is the highest version tag
+        id: latest
+        run: |
+          CURRENT="${GITHUB_REF#refs/tags/v}"
+          HIGHEST=$(git tag -l 'v*' | sed 's/^v//' | sort -V | tail -1)
+          if [ "$CURRENT" = "$HIGHEST" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Current: $CURRENT, Highest: $HIGHEST, is_latest=$( [ "$CURRENT" = "$HIGHEST" ] && echo true || echo false )"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: dramirezrt
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: RAVENCOIN_TAG=${{ steps.meta.outputs.tag }}
+          tags: |
+            dramirezrt/ravencoin-core-server:${{ steps.meta.outputs.tag }}
+            ${{ steps.latest.outputs.is_latest == 'true' && 'dramirezrt/ravencoin-core-server:latest' || '' }}
+          labels: |
+            org.opencontainers.image.title=Ravencoin Core Server
+            org.opencontainers.image.description=Ravencoin Core full node with ZMQ support, built from source
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+            org.opencontainers.image.source=https://github.com/dramirezRT/rvn-core-server-docker
+
+      - name: Fetch upstream release notes
+        id: upstream
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          BODY=$(curl -sf "https://api.github.com/repos/RavenProject/Ravencoin/releases/tags/${TAG}" \
+            | jq -r '.body // empty' 2>/dev/null || true)
+
+          {
+            echo "notes<<RELEASE_EOF"
+            echo "## Docker Image"
+            echo ""
+            echo "\`\`\`"
+            echo "docker pull dramirezrt/ravencoin-core-server:${TAG}"
+            echo "\`\`\`"
+            echo ""
+            echo "### Docker Image Changes"
+            echo "- Base image: Ubuntu 22.04 LTS"
+            echo "- Built from source with ZMQ support"
+            echo "- Ravencoin Core: ${TAG}"
+            echo ""
+            if [ -n "$BODY" ]; then
+              echo "### Upstream Ravencoin Changes"
+              echo ""
+              echo "$BODY"
+              echo ""
+            fi
+            echo "---"
+            echo ""
+            echo "**Full upstream release:** https://github.com/RavenProject/Ravencoin/releases/tag/${TAG}"
+            echo "RELEASE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: Ravencoin Core Server ${{ steps.meta.outputs.tag }}
+          body: ${{ steps.upstream.outputs.notes }}
+          draft: false
+          prerelease: false
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: dramirezrt
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: dramirezrt/ravencoin-core-server
+          readme-filepath: ./README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ COPY --chown=kingofthenorth:kingofthenorth ./rvn-node-frontend-docker /home/king
 WORKDIR /home/kingofthenorth
 
 # P2P
-EXPOSE 8767
+EXPOSE 38767
 # Transmission (bootstrap seeding)
 EXPOSE 31413/tcp
 EXPOSE 31413/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,63 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04 AS builder
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -qq update && apt-get -qq upgrade -y
+ARG RAVENCOIN_TAG=v4.6.1
 
-RUN apt-get -qq update && apt-get install -qq -y \
-    jq unzip tar fail2ban curl wget gawk sed vim tree \
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential libtool autotools-dev automake pkg-config \
+    libssl-dev libevent-dev bsdmainutils python3 \
+    libboost-system-dev libboost-filesystem-dev libboost-chrono-dev \
+    libboost-program-options-dev libboost-test-dev libboost-thread-dev \
+    libzmq3-dev libminiupnpc-dev \
+    git curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Clone and build ravend from source with ZMQ support
+RUN git clone --branch ${RAVENCOIN_TAG} --depth 1 \
+    https://github.com/RavenProject/Ravencoin.git /tmp/ravencoin
+
+WORKDIR /tmp/ravencoin
+
+# Install Berkeley DB 4.8
+RUN ./contrib/install_db4.sh /opt/db4
+
+# Build ravend and raven-cli (no GUI, no wallet, with ZMQ + UPnP)
+RUN ./autogen.sh && \
+    export BDB_PREFIX="/opt/db4" && \
+    ./configure \
+      --disable-tests \
+      --disable-bench \
+      --disable-gui-tests \
+      --without-gui \
+      --with-zmq \
+      --with-miniupnpc \
+      --disable-wallet \
+      LDFLAGS="-L${BDB_PREFIX}/lib/" \
+      CPPFLAGS="-I${BDB_PREFIX}/include/" && \
+    make -j$(nproc) && \
+    strip src/ravend src/raven-cli
+
+# ---------- runtime ----------
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    jq curl wget gawk sed vim tree \
+    libzmq5 libevent-2.1-7 libminiupnpc17 \
+    libboost-system1.74.0 libboost-filesystem1.74.0 \
+    libboost-chrono1.74.0 libboost-program-options1.74.0 \
+    libboost-thread1.74.0 \
     transmission-daemon nodejs npm && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash kingofthenorth
+
+# Copy built binaries from builder
+COPY --from=builder /tmp/ravencoin/src/ravend /usr/local/bin/ravend
+COPY --from=builder /tmp/ravencoin/src/raven-cli /usr/local/bin/raven-cli
 
 VOLUME [ "/home/kingofthenorth/" ]
 VOLUME [ "/kingofthenorth/" ]
@@ -18,13 +66,9 @@ COPY ./files/rvn_init /usr/local/bin/raven_init
 COPY ./files/raven_status /usr/local/bin/raven_status
 COPY ./files/entrypoint /usr/local/bin/entrypoint
 
-ENV TAG latest
-
-# Setup raven init script
 RUN chmod +x /usr/local/bin/raven_init && \
-    /usr/local/bin/raven_init install_rvn
-RUN chmod +x /usr/local/bin/raven_status
-RUN chmod +x /usr/local/bin/entrypoint
+    chmod +x /usr/local/bin/raven_status && \
+    chmod +x /usr/local/bin/entrypoint
 
 COPY --chown=kingofthenorth:kingofthenorth ./files/raven.conf /home/kingofthenorth/.raven/
 
@@ -38,12 +82,17 @@ COPY --chown=kingofthenorth:kingofthenorth ./files/rvn-bootstrap*.tar.gz.torrent
 # Setup nodejs app
 COPY --chown=kingofthenorth:kingofthenorth ./rvn-node-frontend-docker /home/kingofthenorth/nodejs-app/
 
-#USER kingofthenorth
 WORKDIR /home/kingofthenorth
 
-EXPOSE 38767
+# P2P
+EXPOSE 8767
+# Transmission (bootstrap seeding)
 EXPOSE 31413/tcp
 EXPOSE 31413/udp
+# Frontend
 EXPOSE 8080
+# ZMQ notifications
+EXPOSE 28332
+EXPOSE 28333
 
 ENTRYPOINT /usr/local/bin/entrypoint "/usr/local/bin/raven_init init"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ docker run -d \
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `UPNP` | `false` | Enable UPnP port forwarding (use with `--net=host`) |
-| `RAVEN_PORT` | `38767` | Ravencoin P2P port |
+| `RAVEN_PORT` | `38767` | Ravencoin P2P port (official Ravencoin mainnet port is `8767`) |
 | `TRANSMISSION_PORT` | — | Custom BitTorrent port for bootstrap seeding |
 | `FRONTEND_PORT` | `8080` | Status frontend port |
 | `UACOMMENT` | _(empty)_ | Custom user agent comment for the node |

--- a/README.md
+++ b/README.md
@@ -1,66 +1,174 @@
 # rvn-core-server-docker
 
-## Description
-Images are built from the Official Ravencoin Core Server Repository for the Ravencoin Project https://github.com/RavenProject/Ravencoin/releases
+Dockerized Ravencoin Core full node, built from source with **ZMQ notification support**.
 
-## Build
-Using docker engine you can build your own image with:
-```
-    docker build -t <your-docker-user>/<your-repo-name>:<tag>
-```
-or
+## Docker Hub
 
+Pre-built images: [dramirezrt/ravencoin-core-server](https://hub.docker.com/r/dramirezrt/ravencoin-core-server)
+
+```bash
+docker pull dramirezrt/ravencoin-core-server:latest
 ```
-    docker build -t <repo-name>:<tag>
-```
-## What it does?
-The built container will be in charge of:
-1. Downloading and sharing the Ravencoin bootstrap file.
-2. Install and setup the Raven Core node
-3. Run a simple website to monitor the node status
+
+### Available Tags
+
+| Tag | Ravencoin Core | Base Image | ZMQ | Notes |
+|-----|---------------|------------|-----|-------|
+| `v4.6.1` | 4.6.1 | Ubuntu 22.04 | ✅ | Built from source |
+| `v2.3.1` | — | Ubuntu 20.04 | ❌ | Legacy (pre-built binary) |
+| `v2.3` | — | Ubuntu 20.04 | ❌ | Legacy |
+| `v2.0` | — | Ubuntu 20.04 | ❌ | Legacy |
+| `v1.1` | — | Ubuntu 20.04 | ❌ | Legacy |
+
+## What It Does
+
+1. Downloads and seeds the Ravencoin bootstrap file via BitTorrent
+2. Runs the Raven Core full node (`ravend`) — built from source with ZMQ
+3. Serves a simple status monitoring frontend
+4. Exposes ZMQ pub/sub endpoints for real-time block and transaction notifications
+
+## Features
+
+- **Built from source** — not pre-compiled binaries, so ZMQ and UPnP are fully supported
+- **ZMQ notifications** — real-time `hashblock` and `hashtx` events for downstream services
+- **REST API** — enabled by default (`rest=1`) for block/tx data retrieval
+- **Bootstrap seeding** — BitTorrent-based blockchain bootstrap for faster initial sync
+- **Environment variables** — configurable ports, UPnP, ZMQ, and user agent
 
 ## Usage
-Pre-built image based from this repo's tags can be found here [https://hub.docker.com/repository/docker/dramirezrt/ravencoin-core-server](https://hub.docker.com/repository/docker/dramirezrt/ravencoin-core-server)
 
-## Normal usage
-```
+### Basic
+
+```bash
 docker run -d \
-            -v ~/raven-node/kingofthenorth/:/kingofthenorth \
-            -v /home/kingofthenorth \
-            -p 31413:31413/tcp \
-            -p 31413:31413/udp \
-            -p 38767:38767 \
-            -p 8080:8080 \
-            --name rvn-node dramirezrt/ravencoin-core-server:latest
+  -v ~/raven-node/kingofthenorth/:/kingofthenorth \
+  -v /home/kingofthenorth \
+  -p 31413:31413/tcp \
+  -p 31413:31413/udp \
+  -p 38767:38767 \
+  -p 8080:8080 \
+  --name rvn-node dramirezrt/ravencoin-core-server:latest
 ```
 
-## UPNP enabled
-```
+### With UPnP (host networking)
+
+```bash
 docker run -d \
-            -v ~/raven-node/kingofthenorth/:/kingofthenorth \
-            -v /home/kingofthenorth \
-            -e UPNP=true \
-            --net=host \
-            --name rvn-node dramirezrt/ravencoin-core-server:latest
+  -v ~/raven-node/kingofthenorth/:/kingofthenorth \
+  -v /home/kingofthenorth \
+  -e UPNP=true \
+  --net=host \
+  --name rvn-node dramirezrt/ravencoin-core-server:latest
 ```
 
-## Custom port setting
-```
+### With ZMQ Enabled
+
+```bash
 docker run -d \
-            -v ~/raven-node/kingofthenorth/:/kingofthenorth \
-            -v /home/kingofthenorth \
-            -e UPNP=true \
-            -e RAVEN_PORT=8767 \
-            -e TRANSMISSION_PORT=51413 \
-            -e FRONTEND_PORT=8069 \
-            --net=host \
-            --name rvn-node dramirezrt/ravencoin-core-server:latest
+  -v ~/raven-node/kingofthenorth/:/kingofthenorth \
+  -v /home/kingofthenorth \
+  -e ZMQ_HASHBLOCK_PORT=28332 \
+  -e ZMQ_HASHTX_PORT=28333 \
+  -p 38767:38767 \
+  -p 28332:28332 \
+  -p 28333:28333 \
+  -p 8080:8080 \
+  --name rvn-node dramirezrt/ravencoin-core-server:latest
 ```
 
-I included the ravend help output to have it handy for any additional/special configuration for flags, available at [https://github.com/dramirezRT/rvn-core-server-docker/blob/main/ravend-help.log](https://github.com/dramirezRT/rvn-core-server-docker/blob/main/ravend-help.log)
+### Full Custom Configuration
 
+```bash
+docker run -d \
+  -v ~/raven-node/kingofthenorth/:/kingofthenorth \
+  -v /home/kingofthenorth \
+  -e UPNP=true \
+  -e RAVEN_PORT=8767 \
+  -e TRANSMISSION_PORT=51413 \
+  -e FRONTEND_PORT=8069 \
+  -e ZMQ_HASHBLOCK_PORT=28332 \
+  -e ZMQ_HASHTX_PORT=28333 \
+  -e UACOMMENT=MyNode \
+  --net=host \
+  --name rvn-node dramirezrt/ravencoin-core-server:latest
+```
 
-### For donations
-RVN address: RFxiRVE8L7MHVYfNP2X9eMMKUPk83uYfpZ
+## Environment Variables
 
-FLUX address: t1ZsWHkFRfutSMCY1KPyk35k2pkNJ2GPjPU
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `UPNP` | `false` | Enable UPnP port forwarding (use with `--net=host`) |
+| `RAVEN_PORT` | `38767` | Ravencoin P2P port |
+| `TRANSMISSION_PORT` | — | Custom BitTorrent port for bootstrap seeding |
+| `FRONTEND_PORT` | `8080` | Status frontend port |
+| `UACOMMENT` | _(empty)_ | Custom user agent comment for the node |
+| `ZMQ_HASHBLOCK_PORT` | _(disabled)_ | Enable ZMQ hashblock notifications on this port |
+| `ZMQ_HASHTX_PORT` | _(disabled)_ | Enable ZMQ hashtx notifications on this port |
+
+## Exposed Ports
+
+| Port | Protocol | Service |
+|------|----------|---------|
+| `38767` | TCP | Ravencoin P2P (mainnet default) |
+| `31413` | TCP/UDP | BitTorrent (bootstrap seeding) |
+| `8080` | TCP | Status monitoring frontend |
+| `28332` | TCP | ZMQ hashblock notifications (when enabled) |
+| `28333` | TCP | ZMQ hashtx notifications (when enabled) |
+
+## Volumes
+
+| Path | Purpose |
+|------|---------|
+| `/kingofthenorth/` | Blockchain data and bootstrap files (persistent) |
+| `/home/kingofthenorth/` | Application home directory |
+
+## Build From Source
+
+```bash
+# Build with default Ravencoin version (v4.6.1)
+docker build -t ravencoin-core-server .
+
+# Build with specific version
+docker build --build-arg RAVENCOIN_TAG=v4.6.1 -t ravencoin-core-server:v4.6.1 .
+```
+
+## CI/CD
+
+This repo uses GitHub Actions to automatically build and push Docker images on tag push.
+Tags must be on the `main` branch and follow semver (`v*`).
+
+The workflow:
+1. Builds `ravend` from source inside Docker (multi-stage)
+2. Pushes to Docker Hub as `dramirezrt/ravencoin-core-server:<tag>`
+3. Tags `latest` only for the highest semver version
+4. Creates a GitHub Release with upstream release notes
+5. Syncs the README to Docker Hub
+
+The `DOCKER_HUB_TOKEN` secret must be set in the repository settings.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│  rvn-core-server container                      │
+│                                                 │
+│  ┌──────────┐  ┌─────────────┐  ┌───────────┐  │
+│  │  ravend   │  │ transmission│  │  node.js  │  │
+│  │  (core)   │  │  (bootstrap)│  │ (frontend)│  │
+│  └─────┬─────┘  └─────────────┘  └───────────┘  │
+│        │                                         │
+│   P2P :38767                        HTTP :8080   │
+│   ZMQ :28332 (hashblock)                        │
+│   ZMQ :28333 (hashtx)                           │
+│   REST :38766 (API)                             │
+└─────────────────────────────────────────────────┘
+```
+
+## ravend Reference
+
+Full `ravend --help` output is available at [ravend-help.log](ravend-help.log).
+
+## Donations
+
+- **RVN:** RFxiRVE8L7MHVYfNP2X9eMMKUPk83uYfpZ
+- **FLUX:** t1ZsWHkFRfutSMCY1KPyk35k2pkNJ2GPjPU

--- a/files/raven.conf
+++ b/files/raven.conf
@@ -14,3 +14,8 @@ logips=1
 maxconnections=30
 maxuploadtarget=20000
 uacomment=
+rest=1
+
+# ZMQ notifications (uncomment to enable)
+# zmqpubhashblock=tcp://0.0.0.0:28332
+# zmqpubhashtx=tcp://0.0.0.0:28333

--- a/files/rvn_init
+++ b/files/rvn_init
@@ -67,34 +67,6 @@ function setup_nodejs(){
     return 0
 }
 
-function install_rvn() {
-    if [[ -z ${TAG} ]] || [[ ${TAG} == "latest" ]]; then
-        VERSION=$(curl --silent "https://api.github.com/repos/RavenProject/Ravencoin/releases/latest" | jq -r .tag_name)
-        DOWN_URL=$(curl --silent "https://api.github.com/repos/RavenProject/Ravencoin/releases/latest" | jq -r '.assets[] | .browser_download_url' | grep -e ".*x86.*disable-wallet.*")
-        echo "Pulling latest release"
-    else
-        VERSION=$(curl --silent "https://api.github.com/repos/RavenProject/Ravencoin/releases/tags/${TAG}" | jq -r .tag_name)
-        DOWN_URL=$(curl --silent "https://api.github.com/repos/RavenProject/Ravencoin/releases/tags/${TAG}" | jq -r '.assets[] | .browser_download_url' | grep -e ".*x86.*disable-wallet.*")
-        echo "Pulling release ${TAG}"
-    fi
-
-    cd /tmp
-    wget $DOWN_URL
-    local zip_file=$(find . -type f -name '*.zip' 2>/dev/null)
-    extract_file ${zip_file}
-    local targz_file=$(find . -type f -name 'raven*.tar.gz' 2>/dev/null)
-    extract_file ${targz_file}
-    mv $(find . -type d -name 'raven*' 2>/dev/null) /opt/raven
-    ln -sf /opt/raven/bin/ravend /usr/local/bin/ravend
-    ln -sf /opt/raven/bin/raven-cli /usr/local/bin/raven-cli
-
-    local raven_dir=$HOME_DIR/.raven/
-    mkdir -p ${raven_dir}
-    chown -R kingofthenorth:kingofthenorth ${raven_dir}
-
-    rm -rf /tmp/*
-}
-
 function node_status() {
     local bootstrap_file="${HOME_DIR}/bootstrap-status.log"
     if [ -f $bootstrap_file ]; then
@@ -104,7 +76,7 @@ function node_status() {
     if [ -n "${ravend_pid}" ]; then
         local status_file="${HOME_DIR}/node_status.log"
         local curr_t=$(date +%s)
-        local status_file_t=$(date -r ${status_file} +%s)
+        local status_file_t=$(date -r ${status_file} +%s 2>/dev/null || echo 0)
         local diff_t=$[$curr_t - $status_file_t]
         if [ $diff_t -gt 60 ]; then
             raven_status > $status_file
@@ -135,6 +107,14 @@ function check_env_vars() {
     if [ -n "${UACOMMENT}" ]; then
         echo "Setting up custom UACOMMENT to ${UACOMMENT}..."
         sed -i -e "/uacomment=/ s/=.*/=${UACOMMENT}/" ${HOME_DIR}/.raven/raven.conf
+    fi
+    if [ -n "${ZMQ_HASHBLOCK_PORT}" ]; then
+        echo "Enabling ZMQ hashblock on port ${ZMQ_HASHBLOCK_PORT}..."
+        sed -i -e "s|# zmqpubhashblock=.*|zmqpubhashblock=tcp://0.0.0.0:${ZMQ_HASHBLOCK_PORT}|" ${HOME_DIR}/.raven/raven.conf
+    fi
+    if [ -n "${ZMQ_HASHTX_PORT}" ]; then
+        echo "Enabling ZMQ hashtx on port ${ZMQ_HASHTX_PORT}..."
+        sed -i -e "s|# zmqpubhashtx=.*|zmqpubhashtx=tcp://0.0.0.0:${ZMQ_HASHTX_PORT}|" ${HOME_DIR}/.raven/raven.conf
     fi
 }
 


### PR DESCRIPTION
## Summary

Comprehensive modernization of the Ravencoin Core Server Docker image.

### Changes

#### Dockerfile (multi-stage build)
- **Build from source** instead of downloading pre-compiled binaries
  - Fixes ZMQ support — official release binaries were compiled without `--with-zmq`
  - Compiles `ravend` and `raven-cli` with ZMQ + UPnP support
- **Base image upgraded** from Ubuntu 20.04 → 22.04 LTS
- **Multi-stage build** — builder stage compiles, runtime stage is lean
- **New exposed ports**: 28332 (ZMQ hashblock), 28333 (ZMQ hashtx)
- Default P2P port changed to 8767 in EXPOSE (matching common custom configs)

#### raven.conf
- Added `rest=1` — enables the REST API (required by ElectrumX and other services)
- Added commented-out ZMQ config lines (activated via env vars)
- `uacomment` left empty (set via `UACOMMENT` env var per deployment)

#### rvn_init
- Removed `install_rvn` function (binary now built in Dockerfile, not downloaded at runtime)
- Added `ZMQ_HASHBLOCK_PORT` and `ZMQ_HASHTX_PORT` environment variable support
- All other functionality preserved

#### CI/CD (.github/workflows/build-push-release.yml)
- GitHub Actions workflow triggered on `v*` tag push to main
- Builds Docker image and pushes to Docker Hub (`dramirezrt/ravencoin-core-server`)
- Tags `latest` only for the highest semver version
- Creates GitHub Release with upstream release notes
- Syncs README to Docker Hub description

#### README
- Complete rewrite with tags table, environment variables reference, port table
- Build-from-source instructions
- Architecture diagram
- ZMQ usage examples

### Environment Variables (new)
| Variable | Description |
|----------|-------------|
| `ZMQ_HASHBLOCK_PORT` | Enable ZMQ hashblock notifications on this port |
| `ZMQ_HASHTX_PORT` | Enable ZMQ hashtx notifications on this port |

### Notes
- The `DOCKER_HUB_TOKEN` secret must be configured in repo settings (same as Electrumx repo)
- Local raven.conf overrides (ZMQ ports, uacomment) remain on the deployed machine's volume
