### PR TITLE
Fix CI: decouple Docker image tag from Ravencoin source version

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -60,7 +60,6 @@ jobs:
         with:
           context: .
           push: true
-          build-args: RAVENCOIN_TAG=${{ steps.meta.outputs.tag }}
           tags: |
             dramirezrt/ravencoin-core-server:${{ steps.meta.outputs.tag }}
             ${{ steps.latest.outputs.is_latest == 'true' && 'dramirezrt/ravencoin-core-server:latest' || '' }}
@@ -70,11 +69,19 @@ jobs:
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.source=https://github.com/dramirezRT/rvn-core-server-docker
 
+      - name: Extract Ravencoin version from Dockerfile
+        id: rvn
+        run: |
+          RVN_TAG=$(grep -oP 'ARG RAVENCOIN_TAG=\K.*' Dockerfile)
+          echo "tag=$RVN_TAG" >> "$GITHUB_OUTPUT"
+          echo "Ravencoin version from Dockerfile: $RVN_TAG"
+
       - name: Fetch upstream release notes
         id: upstream
         run: |
           TAG="${{ steps.meta.outputs.tag }}"
-          BODY=$(curl -sf "https://api.github.com/repos/RavenProject/Ravencoin/releases/tags/${TAG}" \
+          RVN_TAG="${{ steps.rvn.outputs.tag }}"
+          BODY=$(curl -sf "https://api.github.com/repos/RavenProject/Ravencoin/releases/tags/${RVN_TAG}" \
             | jq -r '.body // empty' 2>/dev/null || true)
 
           {
@@ -88,7 +95,7 @@ jobs:
             echo "### Docker Image Changes"
             echo "- Base image: Ubuntu 22.04 LTS"
             echo "- Built from source with ZMQ support"
-            echo "- Ravencoin Core: ${TAG}"
+            echo "- Ravencoin Core: ${RVN_TAG}"
             echo ""
             if [ -n "$BODY" ]; then
               echo "### Upstream Ravencoin Changes"
@@ -98,7 +105,7 @@ jobs:
             fi
             echo "---"
             echo ""
-            echo "**Full upstream release:** https://github.com/RavenProject/Ravencoin/releases/tag/${TAG}"
+            echo "**Full upstream release:** https://github.com/RavenProject/Ravencoin/releases/tag/${RVN_TAG}"
             echo "RELEASE_EOF"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Problem

The CI pipeline passed the git tag (e.g. `v2.4`) as `RAVENCOIN_TAG` build arg to Docker, meaning it tried to clone Ravencoin source at tag `v2.4` instead of `v4.6.1`. Docker image versioning (v2.x) is independent of the Ravencoin Core version.

## Changes

- **Remove** `build-args: RAVENCOIN_TAG=...` from the build step — Dockerfile default `ARG RAVENCOIN_TAG=v4.6.1` is used instead
- **Add** "Extract Ravencoin version from Dockerfile" step that reads the version directly from the Dockerfile
- **Update** release notes to reference the actual Ravencoin version (`v4.6.1`) instead of the Docker image tag

## Result

When tagging `v2.4`:
- Docker build uses `RAVENCOIN_TAG=v4.6.1` (from Dockerfile)
- Docker Hub image tagged as `dramirezrt/ravencoin-core-server:v2.4`
- Release notes reference Ravencoin Core `v4.6.1`