### PR TITLE
ci: add build validation workflow

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -20,11 +20,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build image (no push)
+      - name: Build image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: false
+          load: true
           tags: dramirezrt/ravencoin-core-server:ci-test
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -32,12 +33,3 @@ jobs:
       - name: Verify ravend binary
         run: |
           docker run --rm --entrypoint ravend dramirezrt/ravencoin-core-server:ci-test --version
-
-      - name: Verify create_snapshot script
-        run: |
-          docker run --rm --entrypoint create_snapshot dramirezrt/ravencoin-core-server:ci-test --help 2>&1 || \
-          docker run --rm --entrypoint /bin/bash dramirezrt/ravencoin-core-server:ci-test -c "test -x /usr/local/bin/create_snapshot && echo 'create_snapshot: OK'"
-
-      - name: Verify pv is available
-        run: |
-          docker run --rm --entrypoint pv dramirezrt/ravencoin-core-server:ci-test --version

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -1,0 +1,43 @@
+name: Build Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: dramirezrt/ravencoin-core-server:ci-test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify ravend binary
+        run: |
+          docker run --rm --entrypoint ravend dramirezrt/ravencoin-core-server:ci-test --version
+
+      - name: Verify create_snapshot script
+        run: |
+          docker run --rm --entrypoint create_snapshot dramirezrt/ravencoin-core-server:ci-test --help 2>&1 || \
+          docker run --rm --entrypoint /bin/bash dramirezrt/ravencoin-core-server:ci-test -c "test -x /usr/local/bin/create_snapshot && echo 'create_snapshot: OK'"
+
+      - name: Verify pv is available
+        run: |
+          docker run --rm --entrypoint pv dramirezrt/ravencoin-core-server:ci-test --version


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the Docker image on every PR to `main` and on every push to `main`.

Validates:
- Image builds successfully (ravend compiled from source)
- `ravend` binary is present and executable

Uses GHA layer cache to keep subsequent builds fast.